### PR TITLE
Small improvements

### DIFF
--- a/library/src/main/java/moe/feng/common/view/breadcrumbs/BreadcrumbsAdapter.java
+++ b/library/src/main/java/moe/feng/common/view/breadcrumbs/BreadcrumbsAdapter.java
@@ -2,6 +2,7 @@ package moe.feng.common.view.breadcrumbs;
 
 import android.content.Context;
 import android.graphics.drawable.Drawable;
+import android.util.TypedValue;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -82,19 +83,24 @@ class BreadcrumbsAdapter extends RecyclerView.Adapter<BreadcrumbsAdapter.ItemHol
 
 	@Override
 	public void onBindViewHolder(@NonNull ItemHolder holder, int position) {
+		onBindViewHolder(holder, position, null);
+	}
+
+	@Override
+	public void onBindViewHolder(@NonNull ItemHolder holder, int position, List<Object> payloads) {
 		int viewType = getItemViewType(position);
-		int truePos = viewType == R.layout.breadcrumbs_view_item_arrow ? ((position - 1) / 2) + 1 : position / 2;
+		int truePos = BreadcrumbsUtil.getTruePosition(viewType, position);
 		holder.setItem(items.get(truePos));
 	}
 
 	@Override
 	public int getItemCount() {
-		return (items != null && !items.isEmpty()) ? (items.size() * 2 - 1) : 0;
+		return BreadcrumbsUtil.getAdapterCount(items);
 	}
 
 	@Override
 	public int getItemViewType(int position) {
-		return position % 2 == 1 ? R.layout.breadcrumbs_view_item_arrow : R.layout.breadcrumbs_view_item_text;
+		return BreadcrumbsUtil.getItemViewType(position);
 	}
 
 	class BreadcrumbItemHolder extends ItemHolder<IBreadcrumbItem> {
@@ -104,14 +110,19 @@ class BreadcrumbsAdapter extends RecyclerView.Adapter<BreadcrumbsAdapter.ItemHol
 		BreadcrumbItemHolder(View itemView) {
 			super(itemView);
 			button = (TextView) itemView;
-			button.setOnClickListener(new View.OnClickListener() {
-				@Override
-				public void onClick(View view) {
-					if (callback != null) {
+			// enable touch feedback only for items that have a callback
+			if (callback != null) {
+				button.setOnClickListener(new View.OnClickListener() {
+					@Override
+					public void onClick(View view) {
 						callback.onItemClick(parent, getAdapterPosition() / 2);
 					}
-				}
-			});
+				});
+			} else {
+				button.setClickable(false);
+			}
+			button.setTextSize(TypedValue.COMPLEX_UNIT_PX, parent.getTextSize());
+			button.setPadding(parent.getTextPadding(), parent.getTextPadding(), parent.getTextPadding(), parent.getTextPadding());
 		}
 
 		@Override
@@ -126,7 +137,6 @@ class BreadcrumbsAdapter extends RecyclerView.Adapter<BreadcrumbsAdapter.ItemHol
 			button.setTextColor(getAdapterPosition() == getItemCount() - 1 ? parent.getSelectedTextColor()
 					: parent.getTextColor());
 		}
-
 	}
 
 	class ArrowIconHolder extends ItemHolder<IBreadcrumbItem> {

--- a/library/src/main/java/moe/feng/common/view/breadcrumbs/BreadcrumbsDiffCallback.java
+++ b/library/src/main/java/moe/feng/common/view/breadcrumbs/BreadcrumbsDiffCallback.java
@@ -1,0 +1,56 @@
+package moe.feng.common.view.breadcrumbs;
+
+import java.util.List;
+
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.DiffUtil;
+import moe.feng.common.view.breadcrumbs.model.IBreadcrumbItem;
+
+public class BreadcrumbsDiffCallback extends DiffUtil.Callback {
+
+    public static String PAYLOAD = "BreadcrumbsDiffCallback_Payload";
+
+    private List<IBreadcrumbItem> oldItems;
+    private List<IBreadcrumbItem> newItems;
+
+    public BreadcrumbsDiffCallback(List<IBreadcrumbItem> newItems, List<IBreadcrumbItem> oldItems) {
+        this.newItems = newItems;
+        this.oldItems = oldItems;
+    }
+
+    @Override
+    public int getOldListSize() {
+        return BreadcrumbsUtil.getAdapterCount(oldItems);
+    }
+
+    @Override
+    public int getNewListSize() {
+        return BreadcrumbsUtil.getAdapterCount(newItems);
+    }
+
+    @Override
+    public boolean areItemsTheSame(int oldItemPosition, int newItemPosition) {
+
+        // we consider same positions as same items
+        return oldItemPosition == newItemPosition;
+    }
+
+    @Override
+    public boolean areContentsTheSame(int oldItemPosition, int newItemPosition) {
+        int type1 = BreadcrumbsUtil.getItemViewType(oldItemPosition);
+        int type2 = BreadcrumbsUtil.getItemViewType(newItemPosition);
+        if (type1 != type2) {
+            return false;
+        }
+        int pos1 = BreadcrumbsUtil.getTruePosition(type1, oldItemPosition);
+        int pos2 = BreadcrumbsUtil.getTruePosition(type2, newItemPosition);
+        boolean areContentsTheSame = oldItems.get(pos1).equals(newItems.get(pos2));
+        return areContentsTheSame;
+    }
+
+    @Nullable
+    @Override
+    public Object getChangePayload(int oldItemPosition, int newItemPosition) {
+        return PAYLOAD;
+    }
+}

--- a/library/src/main/java/moe/feng/common/view/breadcrumbs/BreadcrumbsDiffCallback.java
+++ b/library/src/main/java/moe/feng/common/view/breadcrumbs/BreadcrumbsDiffCallback.java
@@ -30,7 +30,6 @@ public class BreadcrumbsDiffCallback extends DiffUtil.Callback {
 
     @Override
     public boolean areItemsTheSame(int oldItemPosition, int newItemPosition) {
-
         // we consider same positions as same items
         return oldItemPosition == newItemPosition;
     }
@@ -44,8 +43,7 @@ public class BreadcrumbsDiffCallback extends DiffUtil.Callback {
         }
         int pos1 = BreadcrumbsUtil.getTruePosition(type1, oldItemPosition);
         int pos2 = BreadcrumbsUtil.getTruePosition(type2, newItemPosition);
-        boolean areContentsTheSame = oldItems.get(pos1).equals(newItems.get(pos2));
-        return areContentsTheSame;
+        return oldItems.get(pos1).equals(newItems.get(pos2));
     }
 
     @Nullable

--- a/library/src/main/java/moe/feng/common/view/breadcrumbs/BreadcrumbsLayoutManager.java
+++ b/library/src/main/java/moe/feng/common/view/breadcrumbs/BreadcrumbsLayoutManager.java
@@ -1,0 +1,25 @@
+package moe.feng.common.view.breadcrumbs;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+import androidx.recyclerview.widget.LinearLayoutManager;
+
+class BreadcrumbsLayoutManager extends LinearLayoutManager {
+    public BreadcrumbsLayoutManager(Context context) {
+        super(context);
+    }
+
+    public BreadcrumbsLayoutManager(Context context, int orientation, boolean reverseLayout) {
+        super(context, orientation, reverseLayout);
+    }
+
+    public BreadcrumbsLayoutManager(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+    }
+
+    @Override
+    public boolean supportsPredictiveItemAnimations() {
+        return false;
+    }
+}

--- a/library/src/main/java/moe/feng/common/view/breadcrumbs/BreadcrumbsUtil.java
+++ b/library/src/main/java/moe/feng/common/view/breadcrumbs/BreadcrumbsUtil.java
@@ -1,0 +1,19 @@
+package moe.feng.common.view.breadcrumbs;
+
+import java.util.List;
+
+import moe.feng.common.view.breadcrumbs.model.IBreadcrumbItem;
+
+class BreadcrumbsUtil {
+    static int getAdapterCount(List<IBreadcrumbItem> item) {
+        return (item != null && !item.isEmpty()) ? (item.size() * 2 - 1) : 0;
+    }
+
+    static int getItemViewType(int position) {
+        return position % 2 == 1 ? R.layout.breadcrumbs_view_item_arrow : R.layout.breadcrumbs_view_item_text;
+    }
+
+    static int getTruePosition(int viewType, int position) {
+       return viewType == R.layout.breadcrumbs_view_item_arrow ? ((position - 1) / 2) + 1 : position / 2;
+    }
+}

--- a/library/src/main/java/moe/feng/common/view/breadcrumbs/BreadcrumbsView.java
+++ b/library/src/main/java/moe/feng/common/view/breadcrumbs/BreadcrumbsView.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.RecyclerView;
 import moe.feng.common.view.breadcrumbs.model.IBreadcrumbItem;
 
@@ -33,6 +33,8 @@ public class BreadcrumbsView extends FrameLayout {
 
 	private ColorStateList mTextColor;
 	private ColorStateList mSelectedTextColor;
+	private int mTextSize;
+	private int mTextPadding;
 
     private static final String KEY_SUPER_STATES = BuildConfig.APPLICATION_ID + ".superStates";
     private static final String KEY_BREADCRUMBS = BuildConfig.APPLICATION_ID + ".breadcrumbs";
@@ -53,6 +55,8 @@ public class BreadcrumbsView extends FrameLayout {
 			mPopupThemeId = a.getResourceId(R.styleable.BreadcrumbsView_popupTheme, -1);
 			mTextColor = a.getColorStateList(R.styleable.BreadcrumbsView_crumbsTextColor);
 			mSelectedTextColor = a.getColorStateList(R.styleable.BreadcrumbsView_crumbsSelectedTextColor);
+            mTextSize = a.getDimensionPixelSize(R.styleable.BreadcrumbsView_crumbsTextSize, -1);
+            mTextPadding = a.getDimensionPixelSize(R.styleable.BreadcrumbsView_crumbsPadding, -1);
 			a.recycle();
 		}
 
@@ -70,8 +74,7 @@ public class BreadcrumbsView extends FrameLayout {
 			mRecyclerView = new RecyclerView(getContext());
 
 			// Create Horizontal LinearLayoutManager
-			LinearLayoutManager layoutManager = new LinearLayoutManager(
-					getContext(), LinearLayoutManager.HORIZONTAL, ViewUtils.isRtlLayout(getContext()));
+			BreadcrumbsLayoutManager layoutManager = new BreadcrumbsLayoutManager(getContext(), RecyclerView.HORIZONTAL, ViewUtils.isRtlLayout(getContext()));
 			mRecyclerView.setLayoutManager(layoutManager);
 			mRecyclerView.setOverScrollMode(OVER_SCROLL_NEVER);
 
@@ -120,6 +123,18 @@ public class BreadcrumbsView extends FrameLayout {
 				mRecyclerView.smoothScrollToPosition(mAdapter.getItemCount() - 1);
 			}
 		}, 500);
+	}
+
+	/**
+	 * Set breadcrumb items list and animates them correctly with recyclerview diff
+	 *
+	 * @param items Target list
+	 */
+	public <E extends IBreadcrumbItem> void updateItems(@NonNull List<E> items) {
+		DiffUtil.DiffResult diffResult = DiffUtil.calculateDiff(new BreadcrumbsDiffCallback((List<IBreadcrumbItem>)items, mAdapter.getItems()));
+		mAdapter.setItems(items);
+		diffResult.dispatchUpdatesTo(mAdapter);
+		postScroll(-1, 0);
 	}
 
 	/**
@@ -221,6 +236,17 @@ public class BreadcrumbsView extends FrameLayout {
 		super.onRestoreInstanceState(BaseSavedState.EMPTY_STATE);
 	}
 
+	private void postScroll(final int index, final int delay) {
+		mRecyclerView.postDelayed(new Runnable() {
+			@Override
+			public void run() {
+				int max = mAdapter.getItemCount() - 1;
+				int i = index == -1 ? max : Math.max(index, max);
+				mRecyclerView.smoothScrollToPosition(i);
+			}
+		}, delay);
+	}
+
 	public ColorStateList getTextColor() {
 		return mTextColor;
 	}
@@ -228,4 +254,12 @@ public class BreadcrumbsView extends FrameLayout {
 	public ColorStateList getSelectedTextColor() {
 		return mSelectedTextColor;
 	}
+
+	public int getTextSize() {
+	    return mTextSize;
+    }
+
+    public int getTextPadding() {
+	    return mTextPadding;
+    }
 }

--- a/library/src/main/java/moe/feng/common/view/breadcrumbs/model/BreadcrumbItem.java
+++ b/library/src/main/java/moe/feng/common/view/breadcrumbs/model/BreadcrumbItem.java
@@ -101,6 +101,27 @@ public class BreadcrumbItem implements IBreadcrumbItem<String> {
 		return new BreadcrumbItem(Collections.singletonList(title));
 	}
 
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		BreadcrumbItem other = (BreadcrumbItem ) obj;
+		if (mSelectedIndex != other.mSelectedIndex)
+			return false;
+		if (mItems.size() != other.mItems.size())
+			return false;
+		for (int i = 0; i < mItems.size(); i++) {
+			if (!mItems.get(i).equals(other.mItems.get(i))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
     @Override
     public int describeContents() {
         return 0;

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -5,6 +5,8 @@
 		<attr name="popupTheme"/>
 		<attr name="crumbsTextColor" format="color"/>
 		<attr name="crumbsSelectedTextColor" format="color"/>
+		<attr name="crumbsTextSize" format="dimension"/>
+		<attr name="crumbsPadding" format="dimension"/>
 	</declare-styleable>
 
 </resources>

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -3,5 +3,4 @@
 
 	<dimen name="dropdown_offset_y_fix_value">4.5dp</dimen>
 	<dimen name="dropdown_start_padding_increase">24dp</dimen> <!-- 24dp (arrow size) -->
-
 </resources>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -4,5 +4,8 @@
     <style name="BreadcrumbsView">
         <item name="crumbsTextColor">?android:attr/textColorSecondary</item>
         <item name="crumbsSelectedTextColor">?android:attr/textColorPrimary</item>
+        <item name="crumbsTextSize">18sp</item>
+        <item name="crumbsPadding">16dp</item>
     </style>
+
 </resources>


### PR DESCRIPTION
Here's what I changed

- created a diff callback for the default breadcrumb ItemHolder + added an update function that uses this callback to the BreadcrumbsView
- added attributes to theme default breadcrumb text size and padding - with the current 16dp padding you can't use the default breadcrumbs in a small container
- enable touch callback on default breadcrumbs for touchable items only - user should not get the touch feedback if the view is not really touchable
- I created the BreadcrumbsUtil class and moved common functions used in the adapter and the diff callback to this util class

With the diff callback you will get beautiful animations out of the box now and can easily replace breadcrumbs....